### PR TITLE
ICollectionInstance - add method KeyUpdate() to handle 'update' attribute on a key

### DIFF
--- a/src/FluentNHibernate.Testing/ConventionsTests/ApplyingToModel/HasManyCollectionConventionTests.cs
+++ b/src/FluentNHibernate.Testing/ConventionsTests/ApplyingToModel/HasManyCollectionConventionTests.cs
@@ -209,6 +209,22 @@ namespace FluentNHibernate.Testing.ConventionsTests.ApplyingToModel
         }
 
         [Test]
+        public void KeyUpdateShouldSetModelValue()
+        {
+            Convention(x => x.KeyUpdate());
+
+            VerifyModel(x => x.Key.Update.ShouldBeTrue());
+        }
+
+        [Test]
+        public void KeyNotUpdateShouldSetModelValue()
+        {
+            Convention(x => x.Not.KeyUpdate());
+
+            VerifyModel(x => x.Key.Update.ShouldBeFalse());
+        }
+
+        [Test]
         public void ShouldSetTableNameProperty()
         {
             Convention(x => x.Table("xxx"));

--- a/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/CollectionInstance.cs
@@ -128,6 +128,12 @@ namespace FluentNHibernate.Conventions.Instances
             nextBool = true;
         }
 
+        public void KeyUpdate()
+        {
+            mapping.Key.Set(x => x.Update, Layer.Conventions, nextBool);
+            nextBool = true;
+        }
+
         public void Table(string tableName)
         {
             mapping.Set(x => x.TableName, Layer.Conventions, tableName);

--- a/src/FluentNHibernate/Conventions/Instances/ICollectionInstance.cs
+++ b/src/FluentNHibernate/Conventions/Instances/ICollectionInstance.cs
@@ -44,5 +44,6 @@ namespace FluentNHibernate.Conventions.Instances
         new void Sort(string sort);
         void Subselect(string subselect);
         void KeyNullable();
+        void KeyUpdate();
     }
 }


### PR DESCRIPTION
Add ability to specify if key is updatable or not in conventions.
